### PR TITLE
更换 cdnjs 和 Google Fonts 源

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,6 +16,7 @@ defineConfig({
   base: '/',
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],
+    ['link', { rel: 'stylesheet', href: 'https://s4.zstatic.net/ajax/libs/animate.css/4.1.1/animate.min.css', integrity: 'sha384-Gu3KVV2H9d+yA4QDpVB7VcOyhJlAVrcXd0thEjr4KznfaFPLe0xQJyonVxONa4ZC', crossorigin: 'anonymous' }],
     /**
     ['link', { rel: 'manifest', href: '/manifest.json' }],
     ['meta', { name: 'theme-color', content: '#ffffff' }],

--- a/docs/.vitepress/theme/styles/main.scss
+++ b/docs/.vitepress/theme/styles/main.scss
@@ -1,8 +1,8 @@
 // Libs
-@import url(https://fonts.loli.net/css?family=Fira+Code&display=swap);
-@import url(https://fonts.loli.net/css?family=Roboto:400,500,700&display=swap);
-@import url(https://fonts.loli.net/css?family=Noto+Sans+SC:400,500,700&display=swap);
-@import url(https://cdn.staticfile.org/animate.css/4.1.1/animate.min.css);
+@import url(https://fonts.googleapis.com/css?family=Fira+Code&display=swap);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap);
+@import url(https://fonts.googleapis.com/css?family=Noto+Sans+SC:400,500,700&display=swap);
+// @import url(https://cdn.staticfile.org/animate.css/4.1.1/animate.min.css);
 // Partials
 @import './containers/theorem.scss';
 @import './mixins.scss';


### PR DESCRIPTION
已移除来自 `bootcss.com`, `bootcdn.com`, `staticfile.net`, `staticfile.org`, `cdn.polyfill.io` 镜像的任何文件引用，这些镜像源已被发现有 [篡改文件并插入恶意代码](https://sansec.io/research/polyfill-supply-chain-attack) 的行为，可能会导致被跳转至恶意网站。

另外，`fonts.loli.net` 在很早之前就被吊销备案，已没有国内镜像节点，被 GFW 阻断情况非常严重。

因此已替换为带有国内节点的 `fonts.googleapis.com` 官方源。


另外为了防止再次被供应链攻击，已在外部资源加上基于 SHA384 的哈希验证，确保外部文件不被篡改。